### PR TITLE
Add session modes and demo whoami tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repo couples a local MCP STDIO proxy with a Bedrock AgentCore demo runtime.
 - `uv pip install -e .` — install the CLI in editable mode while iterating.
 - `uvx --from . mcp-agentcore-proxy` — run the proxy locally against any MCP client.
 - Configure runtime affinity with `RUNTIME_SESSION_MODE` (`identity`, `session`, or `request`).
-- `uv run scripts/proxy_smoketest.py "$AGENTCORE_AGENT_ARN" --city "Seattle"` — smoke-test the proxy against a runtime; set `AWS_REGION`.
+- `uv run scripts/proxy_smoketest.py "$AGENTCORE_AGENT_ARN"` — smoke-test the proxy against a runtime; set `AWS_REGION`.
 - `make build | push | deploy` — build the server image, push to ECR, and deploy the SAM stack.
 - `make smoke-test` — retrieve the deployed ARN, then invoke the smoketest via `uv run`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This repo couples a local MCP STDIO proxy with a Bedrock AgentCore demo runtime.
 ## Build, Test, and Development Commands
 - `uv pip install -e .` — install the CLI in editable mode while iterating.
 - `uvx --from . mcp-agentcore-proxy` — run the proxy locally against any MCP client.
+- Configure runtime affinity with `RUNTIME_SESSION_MODE` (`identity`, `session`, or `request`).
 - `uv run scripts/proxy_smoketest.py "$AGENTCORE_AGENT_ARN" --city "Seattle"` — smoke-test the proxy against a runtime; set `AWS_REGION`.
 - `make build | push | deploy` — build the server image, push to ECR, and deploy the SAM stack.
 - `make smoke-test` — retrieve the deployed ARN, then invoke the smoketest via `uv run`.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Configure VS Code MCP to launch the proxy with `uvx` and a pre-set runtime ARN. 
 ## Smoke Test
 `scripts/proxy_smoketest.py` exercises the proxy end to end by listing tools, calling `whoami` to reveal the sandbox identifier, fetching `get_weather` for New York, and asking `tell_joke` about programmers.
 ```bash
-uv run scripts/proxy_smoketest.py "$AGENTCORE_AGENT_ARN" --city "Seattle"
+uv run scripts/proxy_smoketest.py "$AGENTCORE_AGENT_ARN"
 ```
 The script spawns `mcp-agentcore-proxy` via STDIO, initializes an MCP session, and prints any tool output. Example output is illustrative. Actual costs depend on traffic patterns and configuration.
 

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import sys
+import uuid
 from typing import Any
 
 from strands import Agent
@@ -29,6 +30,8 @@ mcp = FastMCP(
 # Global instances
 app = mcp.streamable_http_app()
 model = BedrockModel(model_id="amazon.nova-micro-v1:0")
+SANDBOX_ID = str(uuid.uuid4())
+
 agent = Agent(
     model=model,
     system_prompt=(
@@ -76,6 +79,13 @@ Keep it under 40 words."""
             joke_text = result.content.strip()
 
     return {"topic": topic, "message": joke_text}
+
+
+@mcp.tool()
+def whoami() -> dict[str, Any]:
+    """Return the sandbox identifier for this MCP demo server."""
+
+    return {"sandbox_id": SANDBOX_ID}
 
 
 if __name__ == "__main__":

--- a/src/mcp_agentcore_proxy/cli.py
+++ b/src/mcp_agentcore_proxy/cli.py
@@ -60,7 +60,7 @@ class RuntimeSessionManager:
                 "sts:GetCallerIdentity returned incomplete identity"
             )
 
-        uid = f"{account}/{user_id}/{arn}"
+        uid = json.dumps([account, user_id, arn], separators=(",", ":"))
         return hashlib.sha256(uid.encode("utf-8")).hexdigest()
 
     def next_session_id(self) -> str:

--- a/src/mcp_agentcore_proxy/cli.py
+++ b/src/mcp_agentcore_proxy/cli.py
@@ -9,6 +9,7 @@ import json
 import os
 import sys
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 import boto3
@@ -16,6 +17,67 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 DEFAULT_CONTENT_TYPE = "application/json"
 DEFAULT_ACCEPT = "application/json, text/event-stream"
+
+
+class RuntimeSessionError(Exception):
+    """Raised when a runtime session ID cannot be established."""
+
+
+@dataclass(frozen=True)
+class RuntimeSessionConfig:
+    mode: str
+
+
+class RuntimeSessionManager:
+    """Resolve AgentCore runtime session IDs based on configuration."""
+
+    def __init__(self, config: RuntimeSessionConfig):
+        self._mode = config.mode
+        self._session_id: str | None = None
+
+        if self._mode == "identity":
+            self._session_id = self._derive_identity_session_id()
+        elif self._mode == "session":
+            self._session_id = uuid.uuid4().hex
+        elif self._mode == "request":
+            self._session_id = None
+        else:
+            raise RuntimeSessionError(f"Unsupported runtime session mode: {self._mode}")
+
+    @staticmethod
+    def _derive_identity_session_id() -> str:
+        sts = boto3.client("sts")
+        try:
+            ident = sts.get_caller_identity()
+        except (BotoCoreError, ClientError) as exc:
+            raise RuntimeSessionError("Unable to call sts:GetCallerIdentity") from exc
+
+        account = ident.get("Account")
+        user_id = ident.get("UserId")
+        arn = ident.get("Arn")
+        if not all([account, user_id, arn]):
+            raise RuntimeSessionError(
+                "sts:GetCallerIdentity returned incomplete identity"
+            )
+
+        uid = f"{account}/{user_id}/{arn}"
+        return hashlib.sha256(uid.encode("utf-8")).hexdigest()
+
+    def next_session_id(self) -> str:
+        if self._mode == "request":
+            return uuid.uuid4().hex
+
+        if not self._session_id:
+            raise RuntimeSessionError("Runtime session ID was not initialized")
+
+        return self._session_id
+
+
+def _resolve_runtime_session_config() -> RuntimeSessionConfig:
+    mode_env = (os.getenv("RUNTIME_SESSION_MODE") or "").strip().lower()
+    if mode_env:
+        return RuntimeSessionConfig(mode=mode_env)
+    return RuntimeSessionConfig(mode="identity")
 
 
 def _error_response(request_id: Any, code: int, message: str) -> str:
@@ -68,18 +130,13 @@ def main() -> None:
         )
         sys.exit(2)
 
-    sts = boto3.client("sts")
-    try:
-        ident = sts.get_caller_identity()
-    except (BotoCoreError, ClientError):
-        print(
-            _error_response(None, -32000, "Unable to call sts:GetCallerIdentity"),
-            flush=True,
-        )
-        sys.exit(2)
+    config = _resolve_runtime_session_config()
 
-    uid = f"{ident.get('Account', '')}/{ident.get('UserId', '')}/{ident.get('Arn', '')}"
-    runtime_session_id = hashlib.sha256(uid.encode("utf-8")).hexdigest()
+    try:
+        session_manager = RuntimeSessionManager(config)
+    except RuntimeSessionError as exc:
+        print(_error_response(None, -32000, str(exc)), flush=True)
+        sys.exit(2)
 
     client = boto3.client("bedrock-agentcore")
 
@@ -99,10 +156,12 @@ def main() -> None:
         mcp_session_id = "mcp-" + uuid.uuid4().hex
 
         try:
+            next_runtime_session_id = session_manager.next_session_id()
+
             response = client.invoke_agent_runtime(
                 agentRuntimeArn=agent_arn,
                 payload=line.encode("utf-8"),
-                runtimeSessionId=runtime_session_id,
+                runtimeSessionId=next_runtime_session_id,
                 mcpSessionId=mcp_session_id,
                 contentType=DEFAULT_CONTENT_TYPE,
                 accept=DEFAULT_ACCEPT,


### PR DESCRIPTION
This pull request introduces support for configurable runtime session ID modes in the MCP AgentCore proxy, enhances documentation for authentication and tool usage, and improves the demo server and smoketest script to better demonstrate capabilities and identity handling. The most significant changes are grouped below.

**Session ID Management and Authentication:**

* Added a configurable `RUNTIME_SESSION_MODE` environment variable to control how AgentCore `runtimeSessionId` values are generated (`identity`, `session`, or `request`). This is implemented via a new `RuntimeSessionManager` in `cli.py`, improving flexibility for different deployment and authentication scenarios. [[1]](diffhunk://#diff-c9a3b09e55909369b8d6cbaa47596203d9eca01315f1533eda8d5f264c6936d6R22-R82) [[2]](diffhunk://#diff-c9a3b09e55909369b8d6cbaa47596203d9eca01315f1533eda8d5f264c6936d6L71-L83) [[3]](diffhunk://#diff-c9a3b09e55909369b8d6cbaa47596203d9eca01315f1533eda8d5f264c6936d6R159-R164) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R13) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R61)
* Updated documentation to clarify that authentication now uses OAuth 2.0 JWT Bearer, Cognito, or IAM via SigV4, with improved rationale for IAM-based flows and machine-to-machine (M2M) use cases.

**Demo Server and Tooling Enhancements:**

* Added a new `whoami` tool to the demo MCP server (`mcp_server.py`) that returns a unique sandbox identifier, demonstrating session isolation and identity. [[1]](diffhunk://#diff-fdc175b0efd5ff210af43f052f126193ed6c912ee9a50b2eb2eb7fa23ce210ecR4) [[2]](diffhunk://#diff-fdc175b0efd5ff210af43f052f126193ed6c912ee9a50b2eb2eb7fa23ce210ecR33-R34) [[3]](diffhunk://#diff-fdc175b0efd5ff210af43f052f126193ed6c912ee9a50b2eb2eb7fa23ce210ecR84-R90)
* Updated the smoketest script (`proxy_smoketest.py`) to automatically call all available tools (`whoami`, `get_weather`, `tell_joke`) and print their results, removing the need for manual city input. [[1]](diffhunk://#diff-1811060caee5ee48252d094bc25830aec79afa78f3f5b9b8973e3cd5df66371bL21-R42) [[2]](diffhunk://#diff-1811060caee5ee48252d094bc25830aec79afa78f3f5b9b8973e3cd5df66371bL45) [[3]](diffhunk://#diff-1811060caee5ee48252d094bc25830aec79afa78f3f5b9b8973e3cd5df66371bL64-R70) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R86)

**Documentation Improvements:**

* Expanded and clarified documentation in `README.md` to describe the new session ID modes, tool usage, and improved security guidance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R61) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R86) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R129)

These changes make the proxy more flexible, easier to test, and better documented for both developers and machine-to-machine use cases.