### PR TITLE
Fix JSON-RPC notification handling and error responses

### DIFF
--- a/src/mcp_agentcore_proxy/server.py
+++ b/src/mcp_agentcore_proxy/server.py
@@ -151,7 +151,7 @@ class MCPSubprocess:
             line = await reader.readline()
             if not line:
                 return
-            logger.warning(
+            logger.debug(
                 "[subprocess-stderr] %s",
                 line.decode("utf-8", errors="replace").rstrip(),
             )


### PR DESCRIPTION
This pull request refines the handling of JSON-RPC notifications in the client and improves logging in the server. The client now correctly skips most notifications, except for a required initialization notification, and gracefully handles expected HTTP 204 responses. Additionally, server logging for subprocess stderr output is made less verbose.

**JSON-RPC Notification Handling:**

* The client now skips all JSON-RPC notifications except for `notifications/initialized`, ensuring only necessary notifications are processed.
* For error responses, the client uses `-1` as a sentinel value for notification requests without an ID, aligning with JSON-RPC spec.
* The client silently ignores HTTP 204 responses for `notifications/initialized`, as these are expected and not errors.

**Logging Improvements:**

* The server changes subprocess stderr logging from `warning` to `debug`, reducing log verbosity for routine output.